### PR TITLE
Replace lost double quote to make memory killer pickup non web dynos

### DIFF
--- a/lib/papertrail/client.rb
+++ b/lib/papertrail/client.rb
@@ -5,7 +5,7 @@ class PapertrailClient
 
   # Read all logs that that output memory
   def events_with_memory_metrics
-    request('heroku%2Fweb+sample%23memory_total%3D+OR+"error+r14')
+    request('heroku%2Fweb+sample%23memory_total%3D+OR+"error+r14"')
   end
 
   def events_with_load_metrics


### PR DESCRIPTION
This double quote was lost in the refactor done in this commit https://github.com/fleetio/dyno-killer-script/commit/50ca4f46d5a500952a9684216c25ed9d9ed6a27e#diff-5b117755401970c90f901cbfad15840d7a0bcbcd4f537a4249ae7812458bee78 Without it the dyno-killer has only been getting `heroku/web` logs and hasn't been finding the `Error R14` logs. Adding it back in will get the dyno-killer to pickup on sidekiq dynos having R14 errors and automatically restart them.